### PR TITLE
API: Only take prefix as we now provide multiple paths

### DIFF
--- a/lib/src/db.d.ts
+++ b/lib/src/db.d.ts
@@ -1,0 +1,3 @@
+import type { db } from "./internal-types";
+export declare function lookupByName(db: db, pkg: string): any;
+export declare function getAllPackages(db: db): string[];

--- a/lib/src/db.js
+++ b/lib/src/db.js
@@ -1,0 +1,11 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getAllPackages = exports.lookupByName = void 0;
+function lookupByName(db, pkg) {
+    return db[pkg];
+}
+exports.lookupByName = lookupByName;
+function getAllPackages(db) {
+    return Object.keys(db);
+}
+exports.getAllPackages = getAllPackages;

--- a/lib/src/index.d.ts
+++ b/lib/src/index.d.ts
@@ -1,12 +1,12 @@
-import { Logger, IPluginMiddleware, IBasicAuth, IStorageManager, PluginOptions } from "@verdaccio/types";
-import { Application } from "express";
-import { DownloadMetricsConfig } from "../types/index";
+import { Application } from 'express';
+import { IBasicAuth, IPluginMiddleware, Logger, PluginOptions } from '@verdaccio/types';
+import { DownloadMetricsConfig } from '../types/index';
 declare class VerdaccioMiddlewarePlugin implements IPluginMiddleware<DownloadMetricsConfig> {
     logger: Logger;
     private downloadMetricsPath;
     private tarballPath;
     constructor(config: DownloadMetricsConfig, options: PluginOptions<DownloadMetricsConfig>);
-    register_middlewares(app: Application, _auth: IBasicAuth<DownloadMetricsConfig>, storage: IStorageManager<DownloadMetricsConfig>): void;
+    register_middlewares(app: Application, _auth: IBasicAuth<DownloadMetricsConfig>, storage: any): void;
 }
 export { VerdaccioMiddlewarePlugin };
 export default VerdaccioMiddlewarePlugin;

--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -1,4 +1,27 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -13,27 +36,35 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.VerdaccioMiddlewarePlugin = void 0;
-const fs_1 = __importDefault(require("fs"));
 const debug_1 = __importDefault(require("debug"));
-const path_1 = __importDefault(require("path"));
 const express_1 = require("express");
-const debug = (0, debug_1.default)("verdaccio:plugin:download-metrics");
-let defaultTarballPath = "/:pkg/-/:filename";
-let defaultDownloadMetricsPath = "/-/downloads/:pkg";
+const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
+const DB = __importStar(require("./db.js"));
+let FORMAT_VERSION = 1;
+let DB_FILE_NAME = `v${FORMAT_VERSION}-package-download-metrics.json`;
+const debug = (0, debug_1.default)('verdaccio:plugin:download-metrics');
+let defaultTarballPath = '/:pkg/-/:filename';
+let defaultDownloadMetricsPath = '/-/downloads/:pkg';
 class VerdaccioMiddlewarePlugin {
     constructor(config, options) {
         this.logger = options.logger;
         this.downloadMetricsPath = config.downloadMetricsPath;
         this.tarballPath = config.tarballPath;
     }
-    register_middlewares(app, _auth, storage) {
+    /* Should have been,
+  export interface IPluginMiddleware<T> extends IPlugin<T> {
+    register_middlewares(app: any, auth: IBasicAuth<T>, storage: Storage): void;
+  }
+  need to update @verdaccio/ libraries by pinning it to our fork */
+    register_middlewares(app, _auth, storage /* old IStorageManager<DownloadMetricsConfig> */) {
         if (!this.downloadMetricsPath) {
-            debug("downloadMetricsPath is missing in the config. Using the default ${defaultDownloadMetricsPath}");
+            debug(`downloadMetricsPath is missing in the config. Using the default ${defaultDownloadMetricsPath}`);
             this.downloadMetricsPath = defaultDownloadMetricsPath;
             return;
         }
         if (!this.tarballPath) {
-            debug("tarballPath is missing in the config. Using the default ${defaultTarballPath}");
+            debug(`tarballPath is missing in the config. Using the default ${defaultTarballPath}`);
             this.tarballPath = defaultTarballPath;
             return;
         }
@@ -41,11 +72,11 @@ class VerdaccioMiddlewarePlugin {
         const router = (0, express_1.Router)();
         let dbFilePath;
         if (storage.config.storage) {
-            dbFilePath = path_1.default.join(process.cwd(), storage.config.storage, "ligo-registry-package-download-metrics.json");
+            dbFilePath = path_1.default.join(path_1.default.dirname(storage.localStorage.storagePlugin.path), DB_FILE_NAME);
         }
         else {
-            debug("storage.config.storage is not defined");
-            debug("quiting...");
+            debug('storage.config.storage is not defined');
+            debug('quiting...');
             return;
         }
         let db;
@@ -56,30 +87,67 @@ class VerdaccioMiddlewarePlugin {
             //TODO handle e;
             db = {};
         }
-        router.get(this.downloadMetricsPath, (request, res, _next) => __awaiter(this, void 0, void 0, function* () {
+        let downloadsEndpointPath = `${this.downloadMetricsPath}/downloads/:pkg`;
+        debug(`Registering endpoint ${downloadsEndpointPath}`);
+        router.get(downloadsEndpointPath, (request, res, _next) => __awaiter(this, void 0, void 0, function* () {
             let { pkg } = request.params;
             try {
                 res.status(200).json({
-                    downloads: JSON.parse(fs_1.default.readFileSync(dbFilePath).toString())[pkg]
-                        .length,
+                    downloads: JSON.parse(fs_1.default.readFileSync(dbFilePath).toString())[pkg].length,
                 });
             }
             catch (e) {
-                res.status(500);
+                res.status(500).json({ message: 'Internal Server Error' });
             }
         }));
+        let topLastWeekEndpoint = `${this.downloadMetricsPath}/top-last-week`;
+        debug(`Registering endpoint ${topLastWeekEndpoint}`);
+        router.get(topLastWeekEndpoint, (_request, response, _next) => __awaiter(this, void 0, void 0, function* () {
+            let packages = DB.getAllPackages(db);
+            let downloadCountLastWeek = new Map();
+            let today = new Date();
+            let aWeekInMilliseconds = 1000 * 60 * 60 * 24 * 7;
+            let aWeekAgoInMilliseconds = today.getTime() - aWeekInMilliseconds;
+            packages.forEach((pkg) => {
+                let downloadEntries = DB.lookupByName(db, pkg);
+                if (downloadEntries.length) {
+                    downloadEntries.forEach((entry) => {
+                        let downloadTimestamp = new Date(entry.time);
+                        if (downloadTimestamp.getTime() > aWeekAgoInMilliseconds) {
+                            // downloadTimestamp is within a week
+                            let downloadsLastWeek = downloadCountLastWeek.get(pkg) || 0;
+                            downloadCountLastWeek.set(pkg, downloadsLastWeek + 1);
+                        }
+                    });
+                }
+            });
+            let responseData = [];
+            for (let entry of downloadCountLastWeek.entries()) {
+                let [k, v] = entry;
+                let packageMeta = yield storage.getPackageLocalMetadata(k);
+                let { version, author } = packageMeta.versions[packageMeta['dist-tags'].latest];
+                responseData.push({
+                    downloads: v,
+                    name: k,
+                    version,
+                    author, // derived from version
+                });
+            }
+            response.status(200).json(responseData);
+        }));
+        debug(`Hooking endpoint ${this.tarballPath}`);
         router.get(this.tarballPath, (request, _res, next) => {
             // const encryptedString = auth.aesEncrypt(Buffer.from(this.foo, 'utf8'));
             // res.setHeader('X-Verdaccio-Token-Plugin', encryptedString.toString());
             let { pkg } = request.params;
             let downloads = db[pkg] || [];
-            downloads.push({ time: Date.now() });
+            downloads.unshift({ time: Date.now() });
             db[pkg] = downloads;
             fs_1.default.writeFileSync(dbFilePath, JSON.stringify(db, null, 2));
             debug(`Wrote to ${dbFilePath}`);
             next();
         });
-        app.use("/", router);
+        app.use('/', router);
     }
 }
 exports.VerdaccioMiddlewarePlugin = VerdaccioMiddlewarePlugin;

--- a/lib/src/internal-types.d.ts
+++ b/lib/src/internal-types.d.ts
@@ -1,0 +1,1 @@
+export declare type db = any;

--- a/lib/src/internal-types.js
+++ b/lib/src/internal-types.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/lib/src/utils.d.ts
+++ b/lib/src/utils.d.ts
@@ -1,0 +1,8 @@
+/**
+ * Returns the week number for timestamp date.  dowOffset is the day of week the week
+ * "starts" on for your locale - it can be from 0 to 6. If dowOffset is 1 (Monday),
+ * the week returned is the ISO 8601 week number.
+ * @param int dowOffset
+ * @return int
+ */
+export declare function getWeek(timestamp: any, dowOffset?: any): any;

--- a/lib/src/utils.js
+++ b/lib/src/utils.js
@@ -1,0 +1,39 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getWeek = void 0;
+// @ts-nocheck
+/**
+ * Returns the week number for timestamp date.  dowOffset is the day of week the week
+ * "starts" on for your locale - it can be from 0 to 6. If dowOffset is 1 (Monday),
+ * the week returned is the ISO 8601 week number.
+ * @param int dowOffset
+ * @return int
+ */
+function getWeek(timestamp, dowOffset) {
+    dowOffset = typeof dowOffset == 'number' ? dowOffset : 0; //default dowOffset to zero
+    var newYear = new Date(timestamp.getFullYear(), 0, 1);
+    var day = newYear.getDay() - dowOffset; //the day of week the year begins on
+    day = day >= 0 ? day : day + 7;
+    var daynum = Math.floor((timestamp.getTime() -
+        newYear.getTime() -
+        (timestamp.getTimezoneOffset() - newYear.getTimezoneOffset()) * 60000) /
+        86400000) + 1;
+    var weeknum;
+    //if the year starts before the middle of a week
+    if (day < 4) {
+        weeknum = Math.floor((daynum + day - 1) / 7) + 1;
+        if (weeknum > 52) {
+            nYear = new Date(timestamp.getFullYear() + 1, 0, 1);
+            nday = nYear.getDay() - dowOffset;
+            nday = nday >= 0 ? nday : nday + 7;
+            /*if the next year starts before the middle of
+                    the week, it is week #1 of that year*/
+            weeknum = nday < 4 ? 1 : 53;
+        }
+    }
+    else {
+        weeknum = Math.floor((daynum + day - 1) / 7);
+    }
+    return weeknum;
+}
+exports.getWeek = getWeek;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "express": "4.18.1"
   },
   "devDependencies": {
+    "@trivago/prettier-plugin-sort-imports": "*",
+    "prettier": "*",
     "get-port": "*",
     "@types/express": "4.17.13",
     "@types/jest": "27.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,7 @@
 lockfileVersion: 5.3
 
 specifiers:
+  '@trivago/prettier-plugin-sort-imports': '*'
   '@types/express': 4.17.13
   '@types/jest': 27.5.1
   '@types/node': 12.12.5
@@ -14,6 +15,7 @@ specifiers:
   fs-extra: '*'
   get-port: '*'
   jest: 28.1.3
+  prettier: '*'
   request: '*'
   ts-jest: '*'
   typescript: 4.7.4
@@ -25,6 +27,7 @@ dependencies:
   express: 4.18.1
 
 devDependencies:
+  '@trivago/prettier-plugin-sort-imports': 3.3.0_prettier@2.7.1
   '@types/express': 4.17.13
   '@types/jest': 27.5.1
   '@types/node': 12.12.5
@@ -35,6 +38,7 @@ devDependencies:
   fs-extra: 10.1.0
   get-port: 6.1.2
   jest: 28.1.3_@types+node@12.12.5
+  prettier: 2.7.1
   request: 2.88.0
   ts-jest: 28.0.8_jest@28.1.3+typescript@4.7.4
   typescript: 4.7.4
@@ -62,6 +66,29 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
+  /@babel/core/7.17.8:
+    resolution: {integrity: sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.2.0
+      '@babel/code-frame': 7.18.6
+      '@babel/generator': 7.18.12
+      '@babel/helper-compilation-targets': 7.18.9_@babel+core@7.17.8
+      '@babel/helper-module-transforms': 7.18.9
+      '@babel/helpers': 7.18.9
+      '@babel/parser': 7.18.11
+      '@babel/template': 7.18.10
+      '@babel/traverse': 7.18.11
+      '@babel/types': 7.18.10
+      convert-source-map: 1.8.0
+      debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.1
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/core/7.18.10:
     resolution: {integrity: sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==}
     engines: {node: '>=6.9.0'}
@@ -85,6 +112,15 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/generator/7.17.7:
+    resolution: {integrity: sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.18.10
+      jsesc: 2.5.2
+      source-map: 0.5.7
+    dev: true
+
   /@babel/generator/7.18.12:
     resolution: {integrity: sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==}
     engines: {node: '>=6.9.0'}
@@ -92,6 +128,19 @@ packages:
       '@babel/types': 7.18.10
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
+    dev: true
+
+  /@babel/helper-compilation-targets/7.18.9_@babel+core@7.17.8:
+    resolution: {integrity: sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/compat-data': 7.18.8
+      '@babel/core': 7.17.8
+      '@babel/helper-validator-option': 7.18.6
+      browserslist: 4.21.3
+      semver: 6.3.0
     dev: true
 
   /@babel/helper-compilation-targets/7.18.9_@babel+core@7.18.10:
@@ -202,6 +251,14 @@ packages:
       '@babel/helper-validator-identifier': 7.18.6
       chalk: 2.4.2
       js-tokens: 4.0.0
+    dev: true
+
+  /@babel/parser/7.17.8:
+    resolution: {integrity: sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.18.10
     dev: true
 
   /@babel/parser/7.18.11:
@@ -340,6 +397,24 @@ packages:
       '@babel/types': 7.18.10
     dev: true
 
+  /@babel/traverse/7.17.3:
+    resolution: {integrity: sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      '@babel/generator': 7.18.12
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.18.9
+      '@babel/helper-hoist-variables': 7.18.6
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/parser': 7.18.11
+      '@babel/types': 7.18.10
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/traverse/7.18.11:
     resolution: {integrity: sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==}
     engines: {node: '>=6.9.0'}
@@ -356,6 +431,14 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@babel/types/7.17.0:
+    resolution: {integrity: sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.18.6
+      to-fast-properties: 2.0.0
     dev: true
 
   /@babel/types/7.18.10:
@@ -715,6 +798,23 @@ packages:
   /@tootallnate/once/1.1.2:
     resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
     engines: {node: '>= 6'}
+    dev: true
+
+  /@trivago/prettier-plugin-sort-imports/3.3.0_prettier@2.7.1:
+    resolution: {integrity: sha512-1y44bVZuIN0RsS3oIiGd5k8Vm3IZXYZnp4VsP2Z/S5L9WAOw43HE2clso66M2S/dDeJ+8sKPqnHsEfh39Vjs3w==}
+    peerDependencies:
+      prettier: 2.x
+    dependencies:
+      '@babel/core': 7.17.8
+      '@babel/generator': 7.17.7
+      '@babel/parser': 7.17.8
+      '@babel/traverse': 7.17.3
+      '@babel/types': 7.17.0
+      javascript-natural-sort: 0.7.1
+      lodash: 4.17.21
+      prettier: 2.7.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@types/babel__core/7.1.19:
@@ -2576,6 +2676,10 @@ packages:
       istanbul-lib-report: 3.0.0
     dev: true
 
+  /javascript-natural-sort/0.7.1:
+    resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
+    dev: true
+
   /jest-changed-files/28.1.3:
     resolution: {integrity: sha512-esaOfUWJXk2nfZt9SPyC8gA1kNfdKLkQWyzsMlqq8msYSlNKfmZxfRgZn4Cd4MGVUF+7v6dBs0d5TOAKa7iIiA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -3710,6 +3814,12 @@ packages:
     resolution: {integrity: sha512-dLbWOa4xBn+qeWeIF60qRoB6Pk2jX5P3DIVgOQyMyvBpu931Q+8dXz8X0snJiFkQdohDDLnZQECjzsAj75hgZQ==}
     dev: true
 
+  /prettier/2.7.1:
+    resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    dev: true
+
   /pretty-format/27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -4014,6 +4124,11 @@ packages:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
+    dev: true
+
+  /source-map/0.5.7:
+    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /source-map/0.6.1:

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  endOfLine: "lf",
+  useTabs: false,
+  printWidth: 100,
+  tabWidth: 2,
+  singleQuote: true,
+  bracketSpacing: true,
+  trailingComma: "es5",
+  semi: true,
+  plugins: [require("@trivago/prettier-plugin-sort-imports")],
+  importOrder: ["^@verdaccio/(.*)$", "^[./]"],
+  importOrderSeparation: true,
+  importOrderParserPlugins: ["typescript", "classProperties", "jsx"],
+  importOrderSortSpecifiers: true,
+};

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,9 @@
+import type { db } from "./internal-types";
+
+export function lookupByName(db: db, pkg: string) {
+  return db[pkg];
+} 
+
+export function getAllPackages(db: db) {
+  return Object.keys(db);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,47 +1,56 @@
-import fs from "fs";
-import debugF from "debug";
-import path from "path";
-import {
-  Logger,
-  IPluginMiddleware,
-  IBasicAuth,
-  IStorageManager,
-  PluginOptions,
-} from "@verdaccio/types";
-import { Router, Request, Response, NextFunction, Application } from "express";
+import debugF from 'debug';
+import { Application, NextFunction, Request, Response, Router } from 'express';
+import fs from 'fs';
+import path from 'path';
 
-import { DownloadMetricsConfig } from "../types/index";
+import {
+  IBasicAuth,
+  IPluginMiddleware,
+  IStorageManager,
+  Logger,
+  PluginOptions,
+} from '@verdaccio/types';
+
+import { DownloadMetricsConfig } from '../types/index';
+import * as DB from './db.js';
+// @ts-ignore:next-line
+import { getWeek } from './utils';
 
 type downloadEntry = {
   time: number;
 };
 
-const debug = debugF("verdaccio:plugin:download-metrics");
-let defaultTarballPath = "/:pkg/-/:filename";
-let defaultDownloadMetricsPath = "/-/downloads/:pkg"
-class VerdaccioMiddlewarePlugin
-  implements IPluginMiddleware<DownloadMetricsConfig>
-{
+let FORMAT_VERSION = 1;
+let DB_FILE_NAME = `v${FORMAT_VERSION}-package-download-metrics.json`;
+
+const debug = debugF('verdaccio:plugin:download-metrics');
+let defaultTarballPath = '/:pkg/-/:filename';
+let defaultDownloadMetricsPath = '/-/downloads/:pkg';
+
+class VerdaccioMiddlewarePlugin implements IPluginMiddleware<DownloadMetricsConfig> {
   public logger: Logger;
   private downloadMetricsPath: string;
   private tarballPath: string;
-  public constructor(
-    config: DownloadMetricsConfig,
-    options: PluginOptions<DownloadMetricsConfig>
-  ) {
+  public constructor(config: DownloadMetricsConfig, options: PluginOptions<DownloadMetricsConfig>) {
     this.logger = options.logger;
     this.downloadMetricsPath = config.downloadMetricsPath;
     this.tarballPath = config.tarballPath;
   }
 
+  /* Should have been,
+export interface IPluginMiddleware<T> extends IPlugin<T> {
+  register_middlewares(app: any, auth: IBasicAuth<T>, storage: Storage): void;
+}
+need to update @verdaccio/ libraries by pinning it to our fork */
   public register_middlewares(
     app: Application,
     _auth: IBasicAuth<DownloadMetricsConfig>,
-    storage: IStorageManager<DownloadMetricsConfig>
+    storage: any /* old IStorageManager<DownloadMetricsConfig> */
   ): void {
-
     if (!this.downloadMetricsPath) {
-      debug(`downloadMetricsPath is missing in the config. Using the default ${defaultDownloadMetricsPath}`);
+      debug(
+        `downloadMetricsPath is missing in the config. Using the default ${defaultDownloadMetricsPath}`
+      );
       this.downloadMetricsPath = defaultDownloadMetricsPath;
       return;
     }
@@ -51,19 +60,15 @@ class VerdaccioMiddlewarePlugin
       this.tarballPath = defaultTarballPath;
       return;
     }
-    
+
     // eslint new-cap:off
     const router = Router();
     let dbFilePath: string;
     if (storage.config.storage) {
-      dbFilePath = path.join(
-        process.cwd(),
-        storage.config.storage,
-        "ligo-registry-package-download-metrics.json"
-      );
+      dbFilePath = path.join(path.dirname(storage.localStorage.storagePlugin.path), DB_FILE_NAME);
     } else {
-      debug("storage.config.storage is not defined");
-      debug("quiting...");
+      debug('storage.config.storage is not defined');
+      debug('quiting...');
       return;
     }
     let db: any;
@@ -73,8 +78,10 @@ class VerdaccioMiddlewarePlugin
       //TODO handle e;
       db = {};
     }
+    let downloadsEndpointPath = `${this.downloadMetricsPath}/downloads/:pkg`;
+    debug(`Registering endpoint ${downloadsEndpointPath}`);
     router.get(
-      this.downloadMetricsPath,
+      downloadsEndpointPath,
       async (
         request: Request,
         res: Response & { report_error?: Function },
@@ -83,14 +90,62 @@ class VerdaccioMiddlewarePlugin
         let { pkg } = request.params;
         try {
           res.status(200).json({
-            downloads: JSON.parse(fs.readFileSync(dbFilePath).toString())[pkg]
-              .length,
+            downloads: JSON.parse(fs.readFileSync(dbFilePath).toString())[pkg].length,
           });
         } catch (e) {
-          res.status(500);
+          res.status(500).json({ message: 'Internal Server Error' });
         }
       }
     );
+    let topLastWeekEndpoint = `${this.downloadMetricsPath}/top-last-week`;
+    debug(`Registering endpoint ${topLastWeekEndpoint}`);
+    router.get(
+      topLastWeekEndpoint,
+      async (
+        _request: Request,
+        response: Response & { report_error?: Function },
+        _next: NextFunction
+      ): Promise<void> => {
+        let packages = DB.getAllPackages(db);
+        let downloadCountLastWeek = new Map();
+        let today = new Date();
+        let aWeekInMilliseconds = 1000 * 60 * 60 * 24 * 7;
+        let aWeekAgoInMilliseconds = today.getTime() - aWeekInMilliseconds;
+        packages.forEach((pkg) => {
+          let downloadEntries = DB.lookupByName(db, pkg);
+          if (downloadEntries.length) {
+            downloadEntries.forEach((entry: downloadEntry) => {
+              let downloadTimestamp = new Date(entry.time);
+              if (downloadTimestamp.getTime() > aWeekAgoInMilliseconds) {
+                // downloadTimestamp is within a week
+                let downloadsLastWeek = downloadCountLastWeek.get(pkg) || 0;
+                downloadCountLastWeek.set(pkg, downloadsLastWeek + 1);
+              }
+            });
+          }
+        });
+        type response = {
+          downloads: number;
+          name: string;
+          version: string;
+          author: { name: string; email: string };
+        };
+        let responseData: response[] = [];
+        for (let entry of downloadCountLastWeek.entries()) {
+          let [k, v] = entry;
+          let packageMeta = await storage.getPackageLocalMetadata(k);
+          let { version, author } = packageMeta.versions[packageMeta['dist-tags'].latest];
+          responseData.push({
+            downloads: v,
+            name: k,
+            version,
+            author, // derived from version
+          });
+        }
+        response.status(200).json(responseData);
+      }
+    );
+    debug(`Hooking endpoint ${this.tarballPath}`);
     router.get(
       this.tarballPath,
       (
@@ -109,7 +164,7 @@ class VerdaccioMiddlewarePlugin
         next();
       }
     );
-    app.use("/", router);
+    app.use('/', router);
   }
 }
 export { VerdaccioMiddlewarePlugin };

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,7 @@ class VerdaccioMiddlewarePlugin
         // res.setHeader('X-Verdaccio-Token-Plugin', encryptedString.toString());
         let { pkg } = request.params;
         let downloads: Array<downloadEntry> = db[pkg] || [];
-        downloads.push({ time: Date.now() });
+        downloads.unshift({ time: Date.now() });
         db[pkg] = downloads;
         fs.writeFileSync(dbFilePath, JSON.stringify(db, null, 2));
         debug(`Wrote to ${dbFilePath}`);

--- a/src/internal-types.ts
+++ b/src/internal-types.ts
@@ -1,0 +1,1 @@
+export type db = any;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,36 @@
+/**
+ * Returns the week number for timestamp date.  dowOffset is the day of week the week
+ * "starts" on for your locale - it can be from 0 to 6. If dowOffset is 1 (Monday),
+ * the week returned is the ISO 8601 week number.
+ * @param int dowOffset
+ * @return int
+ */
+export function getWeek(timestamp, dowOffset) {
+  dowOffset = typeof dowOffset == 'number' ? dowOffset : 0; //default dowOffset to zero
+  var newYear = new Date(timestamp.getFullYear(), 0, 1);
+  var day = newYear.getDay() - dowOffset; //the day of week the year begins on
+  day = day >= 0 ? day : day + 7;
+  var daynum =
+    Math.floor(
+      (timestamp.getTime() -
+        newYear.getTime() -
+        (timestamp.getTimezoneOffset() - newYear.getTimezoneOffset()) * 60000) /
+        86400000
+    ) + 1;
+  var weeknum;
+  //if the year starts before the middle of a week
+  if (day < 4) {
+    weeknum = Math.floor((daynum + day - 1) / 7) + 1;
+    if (weeknum > 52) {
+      nYear = new Date(timestamp.getFullYear() + 1, 0, 1);
+      nday = nYear.getDay() - dowOffset;
+      nday = nday >= 0 ? nday : nday + 7;
+      /*if the next year starts before the middle of
+              the week, it is week #1 of that year*/
+      weeknum = nday < 4 ? 1 : 53;
+    }
+  } else {
+    weeknum = Math.floor((daynum + day - 1) / 7);
+  }
+  return weeknum;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Returns the week number for timestamp date.  dowOffset is the day of week the week
  * "starts" on for your locale - it can be from 0 to 6. If dowOffset is 1 (Monday),
@@ -5,7 +6,7 @@
  * @param int dowOffset
  * @return int
  */
-export function getWeek(timestamp, dowOffset) {
+export function getWeek(timestamp, dowOffset?) {
   dowOffset = typeof dowOffset == 'number' ? dowOffset : 0; //default dowOffset to zero
   var newYear = new Date(timestamp.getFullYear(), 0, 1);
   var day = newYear.getDay() - dowOffset; //the day of week the year begins on

--- a/test.spec.ts
+++ b/test.spec.ts
@@ -161,7 +161,7 @@ describe("Install and check if download metrics are available", () => {
       middlewares: {
         "package-download-metrics": {
           enabled: true,
-          downloadMetricsPath: "/-/api/downloads/:pkg",
+          downloadMetricsPath: "/-/api/metrics",
           tarballPath: "/:pkg/-/:filename",
         },
       },

--- a/test.spec.ts
+++ b/test.spec.ts
@@ -24,7 +24,7 @@ function runVerdaccioServer(config): Promise<{ webServer: any; addrs: any }> {
 function fetchDownloadMetrics(pkg, port): Promise<number> {
   return new Promise((resolve, reject) => {
     request.get(
-      `/-/api/downloads/${pkg}`,
+      `/-/api/metrics/downloads/${pkg}`,
       { baseUrl: `http://${host}:${port}/` },
       function (error, response, body) {
         if (error) {


### PR DESCRIPTION
This also solves the problem of making sure the variables in the codebase (`request.params.pkg`) don't have to match what the user specifies in the config.